### PR TITLE
upgrade to elm 0.17.0

### DIFF
--- a/List/Safe.elm
+++ b/List/Safe.elm
@@ -1,11 +1,11 @@
-module List.Safe
+module List.Safe exposing
   ( Safe, null, cons, uncons, toList, fromList
   , map, map2, map3, map4, map5, unzip
   , mapl, mapr, reverseMapr, scanl
   , maximum, minimum, head, tail, last
   , member, reverse, all, any
   , sort, sortBy, sortWith
-  ) where
+  )
 
 
 {-|
@@ -79,8 +79,8 @@ import TypeNat exposing (..)
 
 {-| A list with length encoded in its type,
 supporting a restricted set of operations. -}
-type Safe a n =
-  SafeList (List a)
+type Safe a n
+  = SafeList (List a)
 
 
 {-| A list of length 0 -}
@@ -98,8 +98,13 @@ infixr 5 `cons`
 
 {-| Split a non-empty list into a head and a tail -}
 uncons : Safe a (OnePlus n) -> (a, Safe a n)
-uncons (SafeList (h :: t)) =
-  (h, SafeList t)
+uncons l =
+  case l of
+    (SafeList (h :: t)) ->
+      (h, SafeList t)
+
+    (SafeList []) ->
+      Debug.crash "this should never happen"
 
 
 {-| Drop type-level information about this list -}

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,17 +1,16 @@
 {
-    "version": "1.0.0",
+    "version": "2.0.0",
     "summary": "Lists which encode their length in the type",
     "repository": "https://github.com/JoeyEremondi/elm-SafeLists.git",
     "license": "BSD3",
     "source-directories": [
-        "."
+        "src"
     ],
     "exposed-modules": [
         "List.Safe"
     ],
     "dependencies": {
-        "JoeyEremondi/elm-typenats": "1.0.1 <= v < 2.0.0",
-        "elm-lang/core": "2.1.0 <= v < 3.0.0"
+        "elm-lang/core": "4.0.1 <= v < 5.0.0"
     },
-    "elm-version": "0.15.1 <= v < 0.16.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }


### PR DESCRIPTION
I am not sure how to not having to use the Debug.crash call. But the type checking of the compiler should actually make sure that this case is never reached during runtime.
